### PR TITLE
isAHoliday says 2021-12-31 is not a federal holiday but it is

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -123,7 +123,7 @@ module.exports = {
     var date = arguments.length <= 0 || arguments[0] === undefined ? new Date() : arguments[0];
 
     var isHoliday = false;
-    var allForYear = allFederalHolidaysForYear(date.getFullYear());
+    var allForYear = allFederalHolidaysForYear(date.getFullYear()).concat(allFederalHolidaysForYear(date.getFullYear() + 1));
     var mm = date.getMonth(),
         dd = date.getDate();
 

--- a/src/index.js
+++ b/src/index.js
@@ -119,7 +119,7 @@ function allFederalHolidaysForYear(year = (new Date().getFullYear())) {
 module.exports = {
   isAHoliday(date = new Date()) {
     let isHoliday = false;
-    const allForYear = allFederalHolidaysForYear(date.getFullYear());
+    const allForYear = allFederalHolidaysForYear(date.getFullYear()).concat(allFederalHolidaysForYear(date.getFullYear() + 1));
     const mm = date.getMonth(), dd = date.getDate();
 
     for(let holiday of allForYear) {


### PR DESCRIPTION
fix for bug in isAHoliday. 2021-12-31 is observed federal holiday because January 1st 2022 falls on Saturday. isAHoliday returns it as not observed federal holiday because it only looks for holidays within the year of the date so in case of 2021-12-31 it only looks at federal holidays within 2021 but 2021-12-31 is observed holiday that is based on 2022. Quick fix (without any optimization) is to include holidays of the date's year as well as next year when checking if given date is a holiday.