### PR TITLE
Fix: incorrect param type of `allForYear` function

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -32,6 +32,6 @@ export interface Holiday {
 
 export function isAHoliday(date?: Date, params?: Partial<WithHolidayShift & WithUTCDate>): boolean;
 
-export function allForYear(date?: Date, params?: Partial<WithHolidayShift>): Holiday[];
+export function allForYear(year?: number, params?: Partial<WithHolidayShift>): Holiday[];
 
 export function inRange(startDate?: Date, endDate?: Date, params?: Partial<WithHolidayShift>): Holiday[];


### PR DESCRIPTION
The 1st param of `allForYear` function should be a year in numeric format, not a date object.