### PR TITLE
Drop support for Node 12 and 14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node: [12, 14, 16, 18]
+        node: [16, 18]
         tz: [UTC, America/New_York, America/Los_Angeles, America/Phoenix, Asia/Hong_Kong]
     
     name: Node ${{ matrix.node }}, ${{ matrix.tz }} timezone
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/setup-node@d6e3b5539ed7e5ccd26c3459e26c7c817f4e9068
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node}}
       - uses: actions/checkout@af513c7a016048ae468971c52ed77d9562c7c819

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node: [16, 18]
+        node: [16, 18, 20]
         tz: [UTC, America/New_York, America/Los_Angeles, America/Phoenix, Asia/Hong_Kong]
     
     name: Node ${{ matrix.node }}, ${{ matrix.tz }} timezone

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node}}
-      - uses: actions/checkout@af513c7a016048ae468971c52ed77d9562c7c819
+      - uses: actions/checkout@v3
       - name: set timezone
         run: sudo timedatectl set-timezone ${{ matrix.tz }}
       - name: install dependencies

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@18f/us-federal-holidays",
-  "version": "3.0.2",
+  "version": "4.0.0",
   "description": "All about US federal holidays",
   "main": "index.js",
   "keywords": [
@@ -25,7 +25,7 @@
     "url": "git+ssh://git@github.com/18F/us-federal-holidays.git"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=16.0.0"
   },
   "scripts": {
     "lint": "eslint index.test.js index.js",


### PR DESCRIPTION
- Drops deprecated Node versions
  - Node 12 has reached EOL
  - Node 14 reached EOL this month
  - Node 20 was released this month
- Bumps the major version
  - Since we're dropping support for major Node versions, this is a semver breaking change
- Pins GitHub actions to tags rather than commit SHAs
  - There was some security concern around pinning to tags, since tags can be changed arbitrarily but commit SHAs are harder to fake. I think there's still value in pinning to SHAs in some contexts, but here there's really nothing an attacker could do via an action that wouldn't also mean our GitHub wasn't otherwise compromised, so for simplicity's sake, I'm changing the pins to tags.