### PR TITLE
Release v4.0.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,55 @@
+name: publish release
+
+on:
+  push:
+    branches:
+      - releases
+
+permissions:
+  id-token: write
+
+jobs:
+  tests:
+    uses: ./.github/workflows/tests.yml
+  publish:
+    name: publish release
+    needs: [tests]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - name: update to latest npm
+        run: npm i -g npm
+      - name: get new version
+        id: version
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const fs = require("fs/promises");
+            const pkg = JSON.parse(await fs.readFile("./package.json", { encoding: "utf-8" }));
+            core.setOutput("version", pkg.version);
+      - name: install dependencies
+        run: npm ci
+      - name: publish
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: create release
+        uses: oftprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
+        with:
+          name: v${{ steps.version.outputs.version }}
+          tag_name: v${{ steps.versions.outputs.version }}
+      - name: remind author to update the release
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "Version ${{ steps.versions.outputs.version }} has been published to npm and a GitHub release has been created. Don't forget to update the release notes!"
+            })

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node: [12, 14, 16, 18]
+        node: [16, 18]
         tz: [UTC, America/New_York, America/Los_Angeles, America/Phoenix, Asia/Hong_Kong]
     
     name: Node ${{ matrix.node }}, ${{ matrix.tz }} timezone
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/setup-node@d6e3b5539ed7e5ccd26c3459e26c7c817f4e9068
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node}}
       - uses: actions/checkout@af513c7a016048ae468971c52ed77d9562c7c819

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node: [16, 18]
+        node: [16, 18, 20]
         tz: [UTC, America/New_York, America/Los_Angeles, America/Phoenix, Asia/Hong_Kong]
     
     name: Node ${{ matrix.node }}, ${{ matrix.tz }} timezone

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: tests
 
-on: [pull_request, push]
+on: [pull_request, push, workflow_call]
 
 jobs:
   test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node}}
-      - uses: actions/checkout@af513c7a016048ae468971c52ed77d9562c7c819
+      - uses: actions/checkout@v3
       - name: set timezone
         run: sudo timedatectl set-timezone ${{ matrix.tz }}
       - name: install dependencies

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@18f/us-federal-holidays",
-  "version": "3.0.2",
+  "version": "4.0.0",
   "description": "All about US federal holidays",
   "main": "index.js",
   "keywords": [
@@ -25,7 +25,7 @@
     "url": "git+ssh://git@github.com/18F/us-federal-holidays.git"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=16.0.0"
   },
   "scripts": {
     "lint": "eslint index.test.js index.js",


### PR DESCRIPTION
- drop support for Node 12
- drop support for Node 14
- update minimum-supported version to Node 16
- add tests for Node 20
- add provenance data to npm release